### PR TITLE
Add binary build for macOS Apple Silicon architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,3 +103,14 @@ jobs:
         asset_path: ./dasgoclient_osx
         asset_name: dasgoclient_osx
         asset_content_type: application/octet-stream
+
+    - name: Upload OSX/macOS ARM64 binary
+      id: upload-dasgoclient_osx_aarch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./dasgoclient_osx_aarch64
+        asset_name: dasgoclient_osx_aarch64
+        asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,19 @@ build:
 	go clean; rm -rf pkg dasgoclient*; go build ${flags}
 	sed -i -e "s,$(TAG),{{VERSION}},g" main.go
 
-build_all: build_osx build_linux build_power8 build_arm64 build_windows
+build_all: build_osx build_osx_arm64 build_linux build_power8 build_arm64 build_windows
 
 build_osx:
 	sed -i -e "s,{{VERSION}},$(TAG),g" main.go
-	go clean; rm -rf pkg dasgoclient_osx; GOOS=darwin go build ${flags}
+	go clean; rm -rf pkg dasgoclient_osx; GOARCH=amd64 GOOS=darwin go build ${flags}
 	sed -i -e "s,$(TAG),{{VERSION}},g" main.go
 	mv dasgoclient dasgoclient_osx
+
+build_osx_arm64:
+	sed -i -e "s,{{VERSION}},$(TAG),g" main.go
+	go clean; rm -rf pkg dasgoclient_osx_aarch64; GOARCH=arm64 GOOS=darwin go build ${flags}
+	sed -i -e "s,$(TAG),{{VERSION}},g" main.go
+	mv dasgoclient dasgoclient_osx_aarch64
 
 build_linux:
 	sed -i -e "s,{{VERSION}},$(TAG),g" main.go


### PR DESCRIPTION
This adds the binary build for macOS Apple Silicon architecture (`GOARCH=arm64 GOOS=darwin`) to both `Makefile` and the `build.yml` actions file.
I tried to follow the current naming scheme. Added explicit `GOARCH=amd64` for the default OS X build, since otherwise `make build_osx` will lead to different results based on the build system.