### PR TITLE
Add binary build for RiscV64 architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,17 @@ jobs:
         asset_name: dasgoclient_aarch64
         asset_content_type: application/octet-stream
 
+    - name: Upload RISCV64 binary
+      id: upload-dasgoclient_riscv64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./dasgoclient_riscv64
+        asset_name: dasgoclient_riscv64
+        asset_content_type: application/octet-stream
+
     - name: Upload OSX/macOS binary
       id: upload-dasgoclient_osx
       uses: actions/upload-release-asset@v1

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	go clean; rm -rf pkg dasgoclient*; CGO_ENABLED=0 go build ${flags}
 	sed -i -e "s,$(TAG),{{VERSION}},g" main.go
 
-build_all: build_osx build_osx_arm64 build_linux build_power8 build_arm64 build_windows
+build_all: build_osx build_osx_arm64 build_linux build_power8 build_arm64 build_riscv64 build_windows
 
 build_osx:
 	sed -i -e "s,{{VERSION}},$(TAG),g" main.go
@@ -46,6 +46,12 @@ build_arm64:
 	go clean; rm -rf pkg dasgoclient_aarch64; GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build ${flags}
 	sed -i -e "s,$(TAG),{{VERSION}},g" main.go
 	mv dasgoclient dasgoclient_aarch64
+
+build_riscv64:
+	sed -i -e "s,{{VERSION}},$(TAG),g" main.go
+	go clean; rm -rf pkg dasgoclient_riscv64; GOARCH=riscv64 GOOS=linux CGO_ENABLED=0 go build ${flags}
+	sed -i -e "s,$(TAG),{{VERSION}},g" main.go
+	mv dasgoclient dasgoclient_riscv64
 
 build_windows:
 	go clean; rm -rf pkg dasgoclient.exe; GOARCH=amd64 GOOS=windows CGO_ENABLED=0 go build ${flags}


### PR DESCRIPTION
Fixes #38 
This adds support for riscv64 architecture
```
> make build_riscv64
sed -i -e "s,{{VERSION}},v02.04.52,g" main.go
go clean; rm -rf pkg dasgoclient_riscv64; GOARCH=riscv64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w -extldflags -static"
go: downloading github.com/dmwm/das2go v0.0.0-20240109131541-fd40de8cee75
go: downloading github.com/buger/jsonparser v1.1.1
go: downloading github.com/pkg/profile v1.7.0
go: downloading github.com/felixge/fgprof v0.9.3
go: downloading gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
go: downloading github.com/vkuznet/dcr v0.0.0-20220305122652-f04b8bee787b
go: downloading github.com/vkuznet/x509proxy v0.0.0-20210801171832-e47b94db99b6
go: downloading github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
sed -i -e "s,v02.04.52,{{VERSION}},g" main.go
mv dasgoclient dasgoclient_riscv64
> ls
agg.go  BUILD.md  dasgoclient_riscv64  go.mod  go.sum  LICENSE  main.go  main_test.go  Makefile  README.md
> file dasgoclient_riscv64 
dasgoclient_riscv64: ELF 64-bit LSB executable, UCB RISC-V, version 1 (SYSV), statically linked, stripped
```